### PR TITLE
LP-3282: Updated result page labels

### DIFF
--- a/Beis.LearningPlatform.Web/Views/Shared/DiagnosticToolFormViews/_PartialRenderDiagnosticToolEmailAnswer.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/DiagnosticToolFormViews/_PartialRenderDiagnosticToolEmailAnswer.cshtml
@@ -25,11 +25,11 @@
     <div class="govuk-checkboxes">
         <div class="govuk-checkboxes__item">
             <input type="checkbox" class="govuk-checkboxes__input" id="@(controlNameBasePath)hasConsentedToMarketingText" name="@(controlNameBasePath)hasConsentedToMarketingText" value="@Model.emailAnswer.HasConsentedToMarketingText" @(Model.emailAnswer.IsOptedInForMarketing ? "checked" : "")>
-            <label for="HasConsentedToMarketing" class="govuk-label govuk-checkboxes__label">I consent to the Department for Business, Energy & Industrial Strategy (BEIS) contacting me (including through one or more of the third party recipients identified in the privacy policy) by email to keep me informed about news, updates and events relating to Help to Grow: Digital. By ticking the box(es) above I am freely consenting to BEIS (and/or the third party recipients identified in the privacy policy) holding and processing my personal data for these purposes.</label>
+            <label for="@(controlNameBasePath)hasConsentedToMarketingText" class="govuk-label govuk-checkboxes__label">I consent to the Department for Business, Energy & Industrial Strategy (BEIS) contacting me (including through one or more of the third party recipients identified in the privacy policy) by email to keep me informed about news, updates and events relating to Help to Grow: Digital. By ticking the box(es) above I am freely consenting to BEIS (and/or the third party recipients identified in the privacy policy) holding and processing my personal data for these purposes.</label>
         </div>
         <div class="govuk-checkboxes__item">
             <input type="checkbox" class="govuk-checkboxes__input" id="@(controlNameBasePath)hasAcceptedPrivacyPolicyText" name="@(controlNameBasePath)hasAcceptedPrivacyPolicyText" value="@Model.emailAnswer.HasAcceptedPrivacyPolicyText" @(Model.emailAnswer.IsPrivacyPolicyAccepted ? "checked" : "")>
-            <label for="HasAcceptedPrivacyPolicy" class="govuk-label govuk-checkboxes__label">Tick this box to confirm you have read our <a id="link-diagnostictoolformviews-renderdiagnostictoolemailanswer-privacy-policy" href="/privacy" target="_blank">privacy policy</a>.</label>
+            <label for="@(controlNameBasePath)hasAcceptedPrivacyPolicyText" class="govuk-label govuk-checkboxes__label">Tick this box to confirm you have read our <a id="link-diagnostictoolformviews-renderdiagnostictoolemailanswer-privacy-policy" href="/privacy" target="_blank">privacy policy</a>.</label>
         </div>
     </div>
 </div>


### PR DESCRIPTION
The labels for the checkboxes on the skilled module questionnaire result pages are now correctly associated with their input fields:

![Screenshot 2022-08-12 at 21 21 28](https://user-images.githubusercontent.com/238270/184436812-ad10caf7-c591-4915-8954-eabbfdd7558e.png)

This fixes the "Form elements must have labels" accessibility test.