### PR TITLE
LP-3283: Fixed duplicate IDs on module landing page

### DIFF
--- a/Beis.LearningPlatform.Web/Views/Shared/Components/CmsLandingPageHero/Default.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/Components/CmsLandingPageHero/Default.cshtml
@@ -12,24 +12,16 @@
 
     <div class="govuk-grid-row beis-columns-same-height">
         @{
-            <div class="cms-content desktop-only">
-                @if (Model.AlternateLayout)
-                {
-                    await RenderText(Model);
-                    await RenderImage(Model);                
-                }
-                else
-                {
-                    await RenderImage(Model);
-                    await RenderText(Model);
-                }
-            </div>
-            <div class="cms-content mobile-only">
-                @{
-                    await RenderImage(Model);
-                    await RenderText(Model);
-                }
-            </div>
+            @if (Model.AlternateLayout)
+            {
+                await RenderText(Model);
+                await RenderImage(Model);                
+            }
+            else
+            {
+                await RenderImage(Model);
+                await RenderText(Model);
+            }
         }
     </div>
 </div>

--- a/Beis.LearningPlatform.Web/wwwroot/scss/landingPageHero.scss
+++ b/Beis.LearningPlatform.Web/wwwroot/scss/landingPageHero.scss
@@ -34,18 +34,4 @@
             display: none;
         }
     }
-
-    .cms-content {
-        &.desktop-only {
-            @include respond(tablet) {
-                display: none;
-            }
-        }
-
-        &.mobile-only {
-            @include respond(tablet) {
-                display: block;
-            }
-        }
-    }
 }

--- a/Beis.LearningPlatform.Web/wwwroot/scss/main.scss
+++ b/Beis.LearningPlatform.Web/wwwroot/scss/main.scss
@@ -865,38 +865,6 @@ a:focus {
     padding-left: 20px;
 }
 
-.cms-content {
-    &.mobile-only {
-
-        @include respond(xl) { /* Gap in our brakpoints between table and desktop (>641 and <769 has no coverage in beis-mixins. Hide mobile for this gap.) */
-            display: none;
-        }
-
-        @include respond(desktop) {
-            display: none;
-        }
-
-        @include respond(tablet) {
-            display: none;
-        }
-
-        @include respond(mobile) { /* override the xl workaround above */
-            display: block;
-        }
-    }
-
-    &.desktop-only {
-
-        @include respond(tablet) {
-            display: block;
-        }
-
-        @include respond(mobile) {
-            display: none;
-        }
-    }
-}
-
 .link-icon-align {
     margin-bottom: -4px;
 }


### PR DESCRIPTION
Fixed the "IDs of active elements must be unique" WCAG errors on the skilled module landing page.

The reason for the non-unique fields was that the hero content was being rendered to screen twice - once in a "desktop-only" div, and once in a "mobile-only" div.

I've updated the code to instead just render the content once as the styles are already responsive for both desktop and mobile.