### PR TITLE
LP-3284: Set empty alt attribute for link arrow icons

### DIFF
--- a/Beis.LearningPlatform.Web/Views/Shared/CMSPageViews/_PartialSingleLink.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/CMSPageViews/_PartialSingleLink.cshtml
@@ -2,8 +2,7 @@
 <div class="govuk-!-margin-top-2">
     <div>
         <span class="beis-link-icon">
-            <img src="/assets/images/link-arrow.svg" class="svgimg beis-link-icon " width="23" height="24" alt="right-arrow">
-
+            <img src="/assets/images/link-arrow.svg" class="svgimg beis-link-icon " width="23" height="24" alt="">
         </span>
         <a class="govuk-link " href="@Model.linkUrl" aria-label="@Model.linkText"> <span style="font-weight:bold;">@Model.boldLeadLinkText</span><span style="font-weight:normal;">@Model.linkText</span></a>
     </div>

--- a/Beis.LearningPlatform.Web/Views/Shared/Components/CmsLandingPageHero/Default.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/Components/CmsLandingPageHero/Default.cshtml
@@ -62,7 +62,7 @@
                     @if(hero.HasLink)
                     {
                         <div>
-                            <img src="/assets/images/link-icon.png" class="link-icon-align" />
+                            <img src="/assets/images/link-icon.png" class="link-icon-align" alt="" />
                             <a id="@hero.GetGaLinkId("link-landingpagehero-", hero.LinkText)" class="govuk-link" href="@hero.LinkUrl" aria-label="hero.LinkAria">@hero.LinkText</a>
                         </div>
                     }

--- a/Beis.LearningPlatform.Web/Views/Shared/Components/CmsThreeColumnHeroes/Default.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/Components/CmsThreeColumnHeroes/Default.cshtml
@@ -11,7 +11,7 @@
                 <div class="govuk-grid-column-one-third govuk-body">
                     <h3 class="govuk-!-margin-bottom-2">@column.Header</h3>
                     <p class="govuk-!-margin-top-2">@column.Intro</p>
-                    <img src="/assets//images/link-arrow.svg" class="beis-link-icon link-icon-align govuk-!-margin-right-1" width="20" height="20" />
+                    <img src="/assets/images/link-arrow.svg" class="beis-link-icon link-icon-align govuk-!-margin-right-1" width="20" height="20" alt="" />
                     <a id="@column.GetGaLinkId("three-col-link-")" href="@column.LinkUrl" title="@column.LinkText" class="govuk-link">@column.LinkText</a>
                 </div>
             }


### PR DESCRIPTION
The link arrow icons i.e. before "Start Are you digitally ready?" here:

![Screenshot 2022-08-12 at 21 56 45](https://user-images.githubusercontent.com/238270/184443846-51bc0021-8abd-4a0a-9b3c-73da98a89906.png)

Now have empty `alt` attributes as they are decorative images (see https://www.w3.org/WAI/tutorials/images/decision-tree/)

This fixes a number of "Images must have alternate text" accessibility failures.