### PR TITLE
LP-3285: Removed unhelpful aria labels

### DIFF
--- a/Beis.LearningPlatform.Web/Views/Shared/CMSPageViews/_Partial2Columns.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/CMSPageViews/_Partial2Columns.cshtml
@@ -35,7 +35,7 @@
                                 @if (!string.IsNullOrWhiteSpace(link.anchorlink))
                                 {
                                     <a id="link-cmspageviews-2columns-@(link.GetGaLinkId())" class="govuk-link @link.custom_class"
-                                       href="@link.anchorlink" aria-label="@(string.IsNullOrWhiteSpace(link.aria) ? "Read the article on " + link.id : link.aria)">
+                                       href="@link.anchorlink">
                                         @link.label
                                     </a>
                                 }
@@ -43,7 +43,7 @@
                                 @if (!string.IsNullOrWhiteSpace(link.url))
                                 {
                                     <a id="link-cmspageviews-2columns-@(link.GetGaLinkId())" class="govuk-link @link.custom_class"
-                                       href="@link.url" aria-label="@(string.IsNullOrWhiteSpace(link.aria) ? "Read the article on " + link.id : link.aria)">
+                                       href="@link.url">
                                         @Html.Raw(link.label)
                                     </a>
                                 }

--- a/Beis.LearningPlatform.Web/Views/Shared/CMSPageViews/_PartialHeaderImageColumns.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/CMSPageViews/_PartialHeaderImageColumns.cshtml
@@ -42,7 +42,7 @@
                                 @if (!string.IsNullOrWhiteSpace(link.anchorlink))
                                 {
                                     <a id="link-cmspageviews-2columns-@(link.GetGaLinkId())" class="govuk-link @link.custom_class"
-                                       href="@link.anchorlink" aria-label="@(string.IsNullOrWhiteSpace(link.aria) ? "Read the article on " + link.id : link.aria)">
+                                       href="@link.anchorlink">
                                         @link.label
                                     </a>
                                 }
@@ -50,7 +50,7 @@
                                 @if (!string.IsNullOrWhiteSpace(link.url))
                                 {
                                     <a id="link-cmspageviews-2columns-@(link.GetGaLinkId())" class="govuk-link @link.custom_class"
-                                       href="@link.url" aria-label="@(string.IsNullOrWhiteSpace(link.aria) ? "Read the article on " + link.id : link.aria)">
+                                       href="@link.url">
                                         @Html.Raw(link.label)
                                     </a>
                                 }

--- a/Beis.LearningPlatform.Web/Views/Shared/CMSPageViews/_PartialHeroBannerContent.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/CMSPageViews/_PartialHeroBannerContent.cshtml
@@ -40,7 +40,7 @@
                             @if (link.anchorlink != null)
                             {
                                 <a id="link-cmspageviews-herobannercontent-@(link.GetGaLinkId())" class="govuk-link @link.custom_class"
-                                   href="@link.anchorlink" aria-label="@(string.IsNullOrWhiteSpace(link.aria)? "Read the article on " + link.id : link.aria)">
+                                   href="@link.anchorlink">
                                     @Html.Raw(link.label)
                                 </a>
                             }
@@ -48,7 +48,7 @@
                             @if (link.url != null)
                             {
                                 <a id="link-cmspageviews-herobannercontent-@(link.GetGaLinkId())" class="govuk-link @link.custom_class"
-                                   href="@link.url" aria-label="@(string.IsNullOrWhiteSpace(link.aria)? "Read the article on " + link.id : link.aria)">
+                                   href="@link.url">
                                     @Html.Raw(link.label)
                                 </a>
                             }

--- a/Beis.LearningPlatform.Web/Views/Shared/CMSPageViews/_PartialStatistics.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/CMSPageViews/_PartialStatistics.cshtml
@@ -65,7 +65,7 @@
                                     @if (link.anchorlink != null)
                                     {
                                         <a id="link-cmspageviews-statistics-@(link.GetGaLinkId())" class="govuk-link @link.custom_class"
-                                           href="@link.anchorlink" aria-label="@(string.IsNullOrWhiteSpace(link.aria) ? "Read the article on " + link.id : link.aria)">
+                                           href="@link.anchorlink">
                                             @Html.Raw(link.label)
                                         </a>
                                     }
@@ -73,7 +73,7 @@
                                     @if (link.url != null)
                                     {
                                         <a id="link-cmspageviews-statistics-@(link.GetGaLinkId())" class="govuk-link @link.custom_class"
-                                           href="@link.url" aria-label="@(string.IsNullOrWhiteSpace(link.aria) ? "Read the article on " + link.id : link.aria)">
+                                           href="@link.url">
                                             @Html.Raw(link.label)
                                         </a>
                                     }

--- a/Beis.LearningPlatform.Web/Views/Shared/CMSPageViews/_PartialTextLinks.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/CMSPageViews/_PartialTextLinks.cshtml
@@ -27,12 +27,11 @@
                             </span>
                             @if (link.url.StartsWith("http"))
                             {
-                                <a id="link-@(link.GetGaLinkId())" class="govuk-link @link.AlteredCustomClass" href="@linkAction" target="" aria-label="@(string.IsNullOrWhiteSpace(link.aria) ? "Read the article on " + link.id : link.aria)"> @link.label </a>
+                                <a id="link-@(link.GetGaLinkId())" class="govuk-link @link.AlteredCustomClass" href="@linkAction" target=""> @link.label </a>
                             }
                             else
                             {
-                                <a id="link-@(link.GetGaLinkId())" class="govuk-link @link.AlteredCustomClass" href="/@linkAction"
-                                aria-label="@(string.IsNullOrWhiteSpace(link.aria) ? "Read the article on " + link.id : link.aria)"> @link.label </a>
+                                <a id="link-@(link.GetGaLinkId())" class="govuk-link @link.AlteredCustomClass" href="/@linkAction"> @link.label </a>
                             }
                         </div>
                     </div>

--- a/Beis.LearningPlatform.Web/Views/Shared/Components/CmsLandingPageHero/Default.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/Components/CmsLandingPageHero/Default.cshtml
@@ -62,7 +62,7 @@
                     @if(hero.HasLink)
                     {
                         <div>
-                            <img src="/assets/images/link-icon.png" class="link-icon-align" />
+                            <img src="/assets/images/link-icon.png" class="link-icon-align" alt="" />
                             <a id="@hero.GetGaLinkId("link-landingpagehero-", hero.LinkText)" class="govuk-link" href="@hero.LinkUrl">@hero.LinkText</a>
                         </div>
                     }

--- a/Beis.LearningPlatform.Web/Views/Shared/Components/CmsLandingPageHero/Default.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/Components/CmsLandingPageHero/Default.cshtml
@@ -54,7 +54,7 @@
             <div class="govuk-grid-row">
                 <div class="right-column">
                     <h2 class="govuk-heading-l govuk-!-padding-top-3">
-                        <a id="@hero.GetGaLinkId("link-landingpagehero-header-", hero.Header)" class="govuk-link" href="@hero.LinkUrl" aria-label="hero.LinkAria">@hero.Header</a>
+                        <a id="@hero.GetGaLinkId("link-landingpagehero-header-", hero.Header)" class="govuk-link" href="@hero.LinkUrl">@hero.Header</a>
                     </h2>
                     <p class="govuk-body">
                         @hero.Intro
@@ -63,7 +63,7 @@
                     {
                         <div>
                             <img src="/assets/images/link-icon.png" class="link-icon-align" />
-                            <a id="@hero.GetGaLinkId("link-landingpagehero-", hero.LinkText)" class="govuk-link" href="@hero.LinkUrl" aria-label="hero.LinkAria">@hero.LinkText</a>
+                            <a id="@hero.GetGaLinkId("link-landingpagehero-", hero.LinkText)" class="govuk-link" href="@hero.LinkUrl">@hero.LinkText</a>
                         </div>
                     }
                 </div>

--- a/Beis.LearningPlatform.Web/Views/Shared/Components/FullSearchArticle/Default.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/Components/FullSearchArticle/Default.cshtml
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row beis-columns-same-height">
     <div class="govuk-grid-column-full">
         <h3 class="govuk-heading-l govuk-!-padding-top-3">
-            <a id="@Model.FirstLink?.GetGaLinkId("header-")" class="govuk-link" href="@Model.FirstLink.url" aria-label="hero.LinkAria">@Model.Article?.subheader</a>
+            <a id="@Model.FirstLink?.GetGaLinkId("header-")" class="govuk-link" href="@Model.FirstLink.url">@Model.Article?.subheader</a>
         </h3>
     </div>
 </div>
@@ -33,7 +33,7 @@
                 </p>
                 <div>
                     <img src="/assets/images/link-icon.png" class="link-icon-align" />
-                    <a id="@Model.FirstLink?.GetGaLinkId("link-")" class="govuk-link" href="@Model.FirstLink.url" aria-label="hero.LinkAria">@Model.FirstLink.label</a>
+                    <a id="@Model.FirstLink?.GetGaLinkId("link-")" class="govuk-link" href="@Model.FirstLink.url">@Model.FirstLink.label</a>
                 </div>
             </div>
         </div>

--- a/Beis.LearningPlatform.Web/Views/Shared/Components/FullSearchArticle/Default.cshtml
+++ b/Beis.LearningPlatform.Web/Views/Shared/Components/FullSearchArticle/Default.cshtml
@@ -32,7 +32,7 @@
                     @Model.Article?.copy
                 </p>
                 <div>
-                    <img src="/assets/images/link-icon.png" class="link-icon-align" />
+                    <img src="/assets/images/link-icon.png" class="link-icon-align" alt="" />
                     <a id="@Model.FirstLink?.GetGaLinkId("link-")" class="govuk-link" href="@Model.FirstLink.url">@Model.FirstLink.label</a>
                 </div>
             </div>


### PR DESCRIPTION
Removed unhelpful "hero.LinkAria" aria-label attributes. This will allow the links to be read out properly and fixes the WCAG 2.1 AAA "Links with the same name must have a similar purpose" errors on the skill modules landing page.

Before the title "Are you digitally ready?" here:

![Screenshot 2022-08-12 at 22 13 06](https://user-images.githubusercontent.com/238270/184445707-fc57daba-4aca-4684-be75-bb0b5ae65975.png)

Will have been read by a screen reader as "hero.LinkAria". Now it will be read as the actual content of the link "Are you digitally ready?"